### PR TITLE
Simplify the `raytrace::objects::plane`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -193,15 +193,15 @@
                 "-m",
                 "${input:world_module}",
                 "-d",
-                "QCIF",
-                // "-a",
-                // "128",
+                "QVGA",
+                "-a",
+                "128",
                 "-b",
-                "1",
+                "9",
                 "-r",
-                "2",
+                "4",
                 "-s",
-                "0.0"
+                "1.0"
             ],
             "cwd": "${workspaceFolder}/testing",
             "env": {

--- a/projects/basal/include/basal/ieee754.hpp
+++ b/projects/basal/include/basal/ieee754.hpp
@@ -63,6 +63,7 @@ constexpr static precision neg_inf = std::numeric_limits<precision>::infinity() 
 constexpr static precision pos_zero = precision(0.0);
 constexpr static precision neg_zero = precision(-0.0);
 constexpr static precision sqrt_2 = precision(1.414213562373095);      // sqrt(2.0);
+constexpr static precision inv_sqrt_2 = precision(0.707106781186547);  // 1.0/sqrt(2.0);
 constexpr static precision sqrt_3 = precision(1.732050807568877);      // sqrt(3.0);
 constexpr static precision inv_sqrt_3 = precision(0.577350269189626);  // 1.0/sqrt(3.0);
 

--- a/projects/geometry/include/geometry/extra_math.hpp
+++ b/projects/geometry/include/geometry/extra_math.hpp
@@ -74,6 +74,16 @@ R3::point spherical_to_cartesian(R3::point const& spherical_point);
 /// @param in theta The amount in radians (following the right hand rule) to rotate around the axis
 linalg::matrix rotation(R3::vector const& axis, iso::radians const theta);
 
+/// @brief Creates a rotation matrix in Tait-Bryan Angles for an intrinsic rotation.
+/// @param yaw The rotation in radians around the Z axis
+/// @param pitch The rotation in radians around the Y axis
+/// @param roll The rotation in radians around the X axis
+/// @return The rotation matrix
+/// @note The order of the rotations is yaw, pitch, roll
+/// @see https://eecs.qmul.ac.uk/~gslabaugh/publications/euler.pdf
+/// @see https://en.wikipedia.org/wiki/Rotation_matrix
+matrix rotation(iso::radians const& yaw, iso::radians const& pitch, iso::radians const& roll);
+
 /// Joins the matricies horizontally, mxn and mxk to make a mx(n+k) matrix
 template <size_t DIMS>
 matrix rowjoin(matrix& a, vector_<DIMS>& b) noexcept(false) {
@@ -166,6 +176,31 @@ using interpolator = std::function<point(point const&, point const&, mapper, pre
 
 namespace R3 {
 using interpolator = std::function<point(point const&, point const&, mapper, precision)>;
+matrix const identity = matrix::identity(3, 3);
+inline matrix roll(iso::radians rad) {
+    return rotation(R3::basis::X, rad);
+}
+inline matrix roll(precision turns) {
+    iso::turns t{turns};
+    iso::radians r = iso::convert(t);
+    return roll(r);
+}
+inline matrix pitch(iso::radians rad) {
+    return rotation(R3::basis::Y, rad);
+}
+inline matrix pitch(precision turns) {
+    iso::turns t{turns};
+    iso::radians r = iso::convert(t);
+    return pitch(r);
+}
+inline matrix yaw(iso::radians rad) {
+    return rotation(R3::basis::Z, rad);
+}
+inline matrix yaw(precision turns) {
+    iso::turns t{turns};
+    iso::radians r = iso::convert(t);
+    return yaw(iso::radians{turns * iso::tau});
+}
 }  // namespace R3
 
 namespace R4 {

--- a/projects/geometry/include/geometry/vector.hpp
+++ b/projects/geometry/include/geometry/vector.hpp
@@ -308,9 +308,9 @@ public:
     }
 
     friend vector_ negation(vector_ const& a) {
-        vector_ b{a};
-        b *= -1.0_p;
-        return b;
+        vector_ b{a};  // copy
+        b *= -1.0_p;   // scale
+        return b;      // return
     }
 };
 

--- a/projects/geometry/source/extra_math.cpp
+++ b/projects/geometry/source/extra_math.cpp
@@ -96,18 +96,46 @@ R3::point spherical_to_cartesian(R3::point const& spherical_point) {
 }
 
 linalg::matrix rotation(R3::vector const& axis, iso::radians const theta) {
-    precision a = axis[0];
-    precision b = axis[1];
-    precision c = axis[2];
-    precision o = 1.0_p;
-    precision cos_t = std::sin(theta.value + iso::pi / 2.0_p);
+    // @see https://en.wikipedia.org/wiki/Rotation_matrix
+    precision i = axis[0];
+    precision j = axis[1];
+    precision k = axis[2];
+    precision const o = 1.0_p;
+    precision cos_t = std::cos(theta.value);
     precision sin_t = std::sin(theta.value);
     precision one_cos_t = o - cos_t;
-    linalg::matrix r{
-        {{(a * a * one_cos_t) + (o * cos_t), (a * b * one_cos_t) - (c * sin_t), (a * c * one_cos_t) + (b * sin_t)},
-         {(a * b * one_cos_t) + (c * sin_t), (b * b * one_cos_t) + (o * cos_t), (b * c * one_cos_t) - (a * sin_t)},
-         {(a * c * one_cos_t) - (b * sin_t), (b * c * one_cos_t) + (a * sin_t), (c * c * one_cos_t) + (o * cos_t)}}};
-    return r;
+    precision a = (i * i * one_cos_t) + (o * cos_t);
+    precision b = (i * j * one_cos_t) - (k * sin_t);
+    precision c = (i * k * one_cos_t) + (j * sin_t);
+
+    precision d = (i * j * one_cos_t) + (k * sin_t);
+    precision e = (j * j * one_cos_t) + (o * cos_t);
+    precision f = (j * k * one_cos_t) - (i * sin_t);
+
+    precision g = (i * k * one_cos_t) - (j * sin_t);
+    precision h = (j * k * one_cos_t) + (i * sin_t);
+    precision m = (k * k * one_cos_t) + (o * cos_t);
+    return linalg::matrix{{{a, b, c}, {d, e, f}, {g, h, m}}};
+}
+
+linalg::matrix rotation(iso::radians const& yaw, iso::radians const& pitch, iso::radians const& roll) {
+    // @see https://en.wikipedia.org/wiki/Rotation_matrix
+    precision cos_yaw = std::cos(yaw.value);
+    precision sin_yaw = std::sin(yaw.value);
+    precision cos_pitch = std::cos(pitch.value);
+    precision sin_pitch = std::sin(pitch.value);
+    precision cos_roll = std::cos(roll.value);
+    precision sin_roll = std::sin(roll.value);
+    precision a = cos_yaw * cos_pitch;
+    precision b = (cos_yaw * sin_pitch * sin_roll) - (sin_yaw * cos_roll);
+    precision c = (cos_yaw * sin_pitch * cos_roll) + (sin_yaw * sin_roll);
+    precision d = sin_yaw * cos_pitch;
+    precision e = (sin_yaw * sin_pitch * sin_roll) + (cos_yaw * cos_roll);
+    precision f = (sin_yaw * sin_pitch * cos_roll) - (cos_yaw * sin_roll);
+    precision g = -sin_pitch;
+    precision h = cos_pitch * sin_roll;
+    precision i = cos_pitch * cos_roll;
+    return linalg::matrix{{{a, b, c}, {d, e, f}, {g, h, i}}};
 }
 
 bool contained_within_aabb(R3::point const& P, R3::point const& min, R3::point const& max) {

--- a/projects/geometry/test/gtest_extra.cpp
+++ b/projects/geometry/test/gtest_extra.cpp
@@ -233,3 +233,114 @@ TEST(Mappers, LerpFunctors) {
         }
     }
 }
+
+TEST(Rotations, Identity) {
+    ASSERT_MATRIX_EQ(R3::identity, R3::roll(0.0));
+    ASSERT_MATRIX_EQ(R3::identity, R3::pitch(0.0));
+    ASSERT_MATRIX_EQ(R3::identity, R3::yaw(0.0));
+    ASSERT_MATRIX_EQ(R3::identity, R3::roll(1.0));
+    ASSERT_MATRIX_EQ(R3::identity, R3::pitch(1.0));
+    ASSERT_MATRIX_EQ(R3::identity, R3::yaw(1.0));
+}
+
+TEST(Rotations, Rolls) {
+    {
+        R3::vector v = R3::basis::Z;
+        matrix M = R3::roll(0.25);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({0, -1, 0}), a);
+    }
+    {
+        R3::vector v = R3::basis::Y;
+        matrix M = R3::roll(0.25);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({0, 0, 1}), a);
+    }
+    {
+        R3::vector v = R3::basis::X;
+        matrix M = R3::roll(0.25);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({1, 0, 0}), a);
+    }
+    {
+        R3::vector v = R3::basis::Z;
+        matrix M = R3::roll(0.125);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({0, -basal::inv_sqrt_2, basal::inv_sqrt_2}), a);
+    }
+}
+
+TEST(Rotations, Pitch) {
+    {
+        R3::vector v = R3::basis::Z;
+        matrix M = R3::pitch(0.25);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({1, 0, 0}), a);
+    }
+    {
+        R3::vector v = R3::basis::Y;
+        matrix M = R3::pitch(0.25);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({0, 1, 0}), a);
+    }
+    {
+        R3::vector v = R3::basis::X;
+        matrix M = R3::pitch(0.25);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({0, 0, -1}), a);
+    }
+    {
+        R3::vector v = R3::basis::Z;
+        matrix M = R3::pitch(0.125);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({basal::inv_sqrt_2, 0, basal::inv_sqrt_2}), a);
+    }
+}
+
+TEST(Rotations, Yaw) {
+    {
+        R3::vector v = R3::basis::Z;
+        matrix M = R3::yaw(0.25);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({0, 0, 1}), a);
+    }
+    {
+        R3::vector v = R3::basis::Y;
+        matrix M = R3::yaw(0.25);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({-1, 0, 0}), a);
+    }
+    {
+        R3::vector v = R3::basis::X;
+        matrix M = R3::yaw(0.25);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({0, 1, 0}), a);
+    }
+    {
+        R3::vector v = R3::basis::X;
+        matrix M = R3::yaw(0.125);
+        R3::vector a = M * v;
+        ASSERT_VECTOR_EQ(R3::vector({basal::inv_sqrt_2, basal::inv_sqrt_2, 0}), a);
+    }
+}
+
+TEST(Rotations, Compounds) {
+    using namespace iso::operators;
+    // we want to achieve a |1,1,1| vector from a X basis vector
+    // the vector makes an angle of 45 degrees with the x axis
+    // and an angle of 45 degrees with the y axis
+    // but the angle from the XY plane
+    R3::vector f({basal::inv_sqrt_3, basal::inv_sqrt_3, basal::inv_sqrt_3});
+    iso::radians alpha = angle(R3::basis::X, f);
+    iso::radians beta = angle(R3::basis::Y, f);
+    iso::radians gamma = angle(R3::basis::Z, f);
+    iso::radians rise = iso::radians(iso::pi / 2) - gamma;
+    std::cout << "Turns -> palpha: " << alpha.value / iso::tau << " beta: " << beta.value / iso::tau
+              << " gamma: " << gamma.value / iso::tau << " rise: " << rise.value / iso::tau << std::endl;
+    R3::vector v = R3::basis::X;
+    matrix M = rotation(iso::radians{iso::pi / 4}, iso::radians{-rise}, iso::radians{0});
+    //--------------------
+    R3::vector a = M * v;
+    //--------------------
+    ASSERT_VECTOR_EQ(f, a);
+}

--- a/projects/geometry/test/gtest_vector.cpp
+++ b/projects/geometry/test/gtest_vector.cpp
@@ -174,6 +174,16 @@ TEST(VectorTest, StaticsAndNegation) {
     ASSERT_PRECISION_EQ(-1.0_p, (-R3::basis::Z)[2]);
 }
 
+TEST(VectorTest, NegationConstants) {
+    // when referencing the basis vectors, the compiler may optimize so be sure to put the negation in ()
+    ASSERT_EQ(3, (-R3::basis::X).dimensions);
+    ASSERT_EQ(3, (-R3::basis::Y).dimensions);
+    ASSERT_EQ(3, (-R3::basis::Z).dimensions);
+    ASSERT_VECTOR_EQ(R3::vector({-1.0_p, 0.0_p, 0.0_p}), (-R3::basis::X));
+    ASSERT_VECTOR_EQ(R3::vector({0.0_p, -1.0_p, 0.0_p}), (-R3::basis::Y));
+    ASSERT_VECTOR_EQ(R3::vector({0.0_p, 0.0_p, -1.0_p}), (-R3::basis::Z));
+}
+
 TEST(VectorTest, AxisCross) {
     using namespace R3;
     vector xy{cross(basis::X, basis::Y)};  // Copy Construct

--- a/projects/raytrace/demo/main_sphere_surfaces.cpp
+++ b/projects/raytrace/demo/main_sphere_surfaces.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
     vector up = R3::basis::Z;
     vector down = -R3::basis::Z;
 
-    raytrace::objects::plane ground(R3::origin, up);
+    raytrace::objects::plane ground;
     mediums::plain plain_green(colors::green, mediums::ambient::dim, colors::green, mediums::smoothness::barely,
                                mediums::roughness::loose);
 

--- a/projects/raytrace/demo/world_art1.cpp
+++ b/projects/raytrace/demo/world_art1.cpp
@@ -16,7 +16,7 @@ public:
         : look_from{0, 25, 10}
         , look_at{0, 0, 10}
         , sun_rays{raytrace::vector{-20, 0, -21}, colors::white, lights::intensities::dim}
-        , floor{R3::origin, R3::basis::Z, 100.0_p, 100.0_p}
+        , floor{200.0_p}
         , pyramid{look_at, 0}
         , orb{raytrace::point{0, 0, 12}, 2.0_p}
         , halo{raytrace::point{0, 0, 14}, 2.25_p, 0.125_p} {

--- a/projects/raytrace/demo/world_cornell.cpp
+++ b/projects/raytrace/demo/world_cornell.cpp
@@ -25,11 +25,11 @@ public:
                      mediums::roughness::tight)
         , marble0{0.128283_p, 0.2_p, 32.0_p, colors::black, colors::yellow}
         , glass{mediums::refractive_index::glass, 0.02_p, colors::gray}
-        , wall0{raytrace::point{0, 80, 80}, -R3::basis::Y}  // left
-        , wall1{raytrace::point{0, -80, 80}, R3::basis::Y}  // right
-        , wall2{raytrace::point{80, 0, 80}, -R3::basis::X}  // back
-        , wall3{R3::origin, R3::basis::Z}                   // floor
-        , wall4{raytrace::point{0, 0, 160}, -R3::basis::Z}  // ceiling
+        , wall0{raytrace::point{0, 80, 80}, R3::roll(iso::radians{iso::pi / 2})}    // left
+        , wall1{raytrace::point{0, -80, 80}, R3::roll(iso::radians{-iso::pi / 2})}  // right
+        , wall2{raytrace::point{80, 0, 80}, R3::pitch(iso::radians{-iso::pi / 2})}  // back
+        , wall3{}                                                                   // floor
+        , wall4{raytrace::point{0, 0, 160}, R3::pitch(iso::radians{iso::pi})}       // ceiling
         , box{raytrace::point{0, -30, 60}, 20, 20, 60}
         , ball{raytrace::point{0, 30, 30}, 30}
         , top_light{raytrace::point{0, 0, 150}, colors::white, 1E4} {

--- a/projects/raytrace/demo/world_desktoy.cpp
+++ b/projects/raytrace/demo/world_desktoy.cpp
@@ -29,7 +29,7 @@ public:
         // overlap space will be centered 1/2 way between origin and the cutout2
         // cutout2 from base. the center will now be at 0, 0, -7.5_p due to centroid calculation
         , final_base{base, cutout2, raytrace::objects::overlap::type::inclusive}
-        , ground{R3::origin, R3::basis::Z}
+        , ground{}
         , sunlight{raytrace::vector{-2, 2, -1}, colors::white, lights::intensities::bright}
         , prick{raytrace::point{0, 0, 3}, colors::white, lights::intensities::bright} {
         // the final base should sit on the ground

--- a/projects/raytrace/demo/world_example.cpp
+++ b/projects/raytrace/demo/world_example.cpp
@@ -21,7 +21,7 @@ public:
         : world{}
         , look_from{-50, -50, 50}
         , look_at{0, 0, 0}
-        , tilt{{-0.2_p, +0.2_p, 1.0_p}}  // define some surfaces
+        , tilt{rotation(iso::radians(0), iso::radians(0), iso::radians(iso::pi / 5))}
         , plain_yellow{colors::yellow, mediums::ambient::none, colors::yellow, mediums::smoothness::small,
                        mediums::roughness::tight}
         , plain_blue{colors::white, mediums::ambient::none, colors::blue, mediums::smoothness::small,
@@ -42,14 +42,14 @@ public:
         , checker_ball{raytrace::point{0, 30, checker_ball_radius}, checker_ball_radius}
         , checker_ball_ring0{checker_ball.position(), tilt, checker_ball_ring_radius_inner,
                              checker_ball_ring_radius_outer}
-        , checker_ball_ring1{checker_ball.position(), -tilt, checker_ball_ring_radius_inner,
+        , checker_ball_ring1{checker_ball.position(), tilt * -1, checker_ball_ring_radius_inner,
                              checker_ball_ring_radius_outer}
         , cyl_position{-30, 00, 10}
         , top{cyl_position + R3::vector{{0, 0, 10}}}
-        , cap{top, R3::basis::Z, 0, 10}
+        , cap{top, R3::identity, 0, 10}
         , column{cyl_position, 10, 10}
         , polka_dot_cube{raytrace::point{30, 0, 7.5_p}, 7.5_p, 7.5_p, 7.5_p}
-        , ground{R3::origin, R3::basis::Z}
+        , ground{}
         , cone_position{0, 0, 10}
         , inner_cone{cone_position, iso::radians(iso::pi / 12)}
         , bounding_cone{cone_position, 10, 10, 10}
@@ -150,7 +150,7 @@ public:
 protected:
     raytrace::point look_from;
     raytrace::point look_at;
-    vector tilt;
+    matrix tilt;
     // define some surfaces
     plain plain_yellow;
     plain plain_blue;

--- a/projects/raytrace/demo/world_gap.cpp
+++ b/projects/raytrace/demo/world_gap.cpp
@@ -21,8 +21,8 @@ public:
         : world{}  // , look_from{0, -100, 0}
         , look_from{-30, -50, 100}
         , look_at{0, 0, 0}
-        , wall1{R3::origin, R3::basis::Y, 20.0_p}
-        , subgap{R3::origin, R3::basis::X, 30.0_p}
+        , wall1{R3::origin, R3::roll(iso::radians{-iso::pi / 2}), 20.0_p}
+        , subgap{R3::origin, R3::pitch(iso::radians{iso::pi / 2}), 30.0_p}
         , gap{wall1, subgap, raytrace::objects::overlap::type::subtractive}
         , sphere{R3::origin, 15}
         , sunlight{R3::vector{0, 100, -100}, raytrace::colors::white, lights::intensities::blinding} {

--- a/projects/raytrace/demo/world_glass.cpp
+++ b/projects/raytrace/demo/world_glass.cpp
@@ -21,7 +21,7 @@ public:
         , look_at{0, 0, 2.0_p}
         , glass_ball{raytrace::point{0, 0, 5.0_p}, 5.0_p}  //, glass_cube(raytrace::point{0, 10, 2}, 2, 2, 2}
         , toy_ball{raytrace::point{-20, -20, 2.0_p}, 2.0_p}
-        , floor{R3::origin, R3::basis::Z, 100, 100}
+        , floor{200.0_p}
         , ikea_checkers{0.1_p,         colors::blue, colors::yellow, colors::red,  colors::magenta,
                         colors::green, colors::cyan, colors::black,  colors::white}
         , schott_glass{mediums::refractive_index::glass, 0.04_p, colors::red}

--- a/projects/raytrace/demo/world_lenses.cpp
+++ b/projects/raytrace/demo/world_lenses.cpp
@@ -30,7 +30,7 @@ public:
         // , pyramid_bounds{pyramid_center, 5, 5, 10}
         // , pyramid_overlap{pyramid_core, pyramid_bounds, objects::overlap::type::inclusive}
         , glass_donut{raytrace::point{10, -10, 3.5_p}, 5.0_p, 2.5_p}
-        , ground{R3::origin, R3::basis::Z, 100, 100}
+        , ground{200.0_p}
         , sunlight{raytrace::vector{-2, 2, -1}, colors::white, lights::intensities::full}
         , prick{raytrace::point{0, 0, 22}, colors::white, 1E6} {
         convex_lens.position(raytrace::point{0, 0, 5});

--- a/projects/raytrace/demo/world_mirrors.cpp
+++ b/projects/raytrace/demo/world_mirrors.cpp
@@ -25,11 +25,12 @@ public:
         , speck0{raytrace::point{0, 0, 10}, colors::white, 1E2}
         , checkerboard_grid{0.25_p,        colors::blue, colors::yellow, colors::red,  colors::magenta,
                             colors::green, colors::cyan, colors::black,  colors::white}
-        , floor{R3::origin, raytrace::vector{0, -1, 4}.normalized(), 20, 20}
-        , ceiling{raytrace::point(0, 0, 20), raytrace::vector{0, -1, -4}.normalized(), 20, 20}
-        , left{raytrace::point(-10, 0, 10), raytrace::vector{4, -1, 0}.normalized(), 20, 20}
-        , right{raytrace::point(10, 0, 10), raytrace::vector{-4, -1, 0}.normalized(), 20, 20}
-        , back{raytrace::point(0, 5, 10), -R3::basis::Y, 10, 10} {
+        , a{tan(0.25) / iso::tau}
+        , floor{R3::origin, R3::roll(a), 40}
+        , ceiling{raytrace::point(0, 0, 20), R3::roll(0.5 - a), 40}
+        , left{raytrace::point(-10, 0, 10), R3::yaw(-a) * R3::pitch(0.25), 40}
+        , right{raytrace::point(10, 0, 10), R3::yaw(a) * R3::pitch(-0.25), 40}
+        , back{raytrace::point(0, 5, 10), R3::roll(0.25), 20} {
         // assign surfaces and materials
         floor.material(&metals::silver);
         ceiling.material(&metals::silver);
@@ -92,6 +93,7 @@ protected:
     raytrace::lights::bulb light0;
     raytrace::lights::speck speck0;
     mediums::checkerboard checkerboard_grid;
+    precision a;
     raytrace::objects::square floor;
     raytrace::objects::square ceiling;
     raytrace::objects::square left;

--- a/projects/raytrace/demo/world_monochrome.cpp
+++ b/projects/raytrace/demo/world_monochrome.cpp
@@ -24,7 +24,7 @@ public:
         , plain_white{colors::white, mediums::ambient::none, colors::white, mediums::smoothness::none, roughness::tight}
         , checkerboard_grid{0.1_p,         colors::blue, colors::yellow, colors::red,  colors::magenta,
                             colors::green, colors::cyan, colors::black,  colors::white}
-        , floor{R3::origin, R3::basis::Z, 100, 100}
+        , floor{200.0_p}
         , light0{raytrace::point{-5, 0, 10}, 1, colors::white, 10, light_subsamples}
         , light1{raytrace::point{-4, 0, 10}, 1, colors::white, 10, light_subsamples}
         , light2{raytrace::point{-3, 0, 10}, 1, colors::white, 10, light_subsamples}
@@ -44,7 +44,7 @@ public:
         //, cylinder_box{raytrace::point{-2, 3, 2}, 1, 1, 2}
         //, cyl{infinite_cylinder, cylinder_box, overlap::type::inclusive}
         , cyl{raytrace::point{-2, 3, 2}, 2, 1}  // cylinder
-        , cap{raytrace::point{-2, 3, 4}, R3::basis::Z, 0, 1}
+        , cap{raytrace::point{-2, 3, 4}, R3::identity, 0, 1}
         , t0{raytrace::point{3, 7, 0.5_p}, 1.4_p, 0.5_p}
         , cb0{raytrace::point{7, -2, 1}, 1, 1, 1} {
         // assign surfaces and materials

--- a/projects/raytrace/demo/world_monochrome2.cpp
+++ b/projects/raytrace/demo/world_monochrome2.cpp
@@ -24,7 +24,7 @@ public:
         , plain_white{colors::white, mediums::ambient::none, colors::white, mediums::smoothness::none, roughness::tight}
         , checkerboard_grid{0.1_p,         colors::blue, colors::yellow, colors::red,  colors::magenta,
                             colors::green, colors::cyan, colors::black,  colors::white}
-        , floor{R3::origin, R3::basis::Z, 100, 100}
+        , floor{200}
         , light0{raytrace::point{-5, 0, 10}, 1, colors::white, 10, light_subsamples}
         , light1{raytrace::point{-4, 0, 10}, 1, colors::white, 10, light_subsamples}
         , light2{raytrace::point{-3, 0, 10}, 1, colors::white, 10, light_subsamples}
@@ -45,9 +45,9 @@ public:
         // , cylinder_caps{raytrace::point{-2, 3, 2}, R3::basis::Z, 2}  // infinite wall
         // , cyl{infinite_cylinder, cylinder_caps, overlap::type::inclusive}
         , cyl{raytrace::point{-2, 3, 2}, 2, 1}  // cylinder
-        , cap{raytrace::point{-2, 3, 4}, R3::basis::Z, 0, 1}
-        , w0{raytrace::point{8, -3, 0}, R3::basis::X, 2}
-        , w1{raytrace::point{8, -3, 0}, R3::basis::Y, 2}
+        , cap{raytrace::point{-2, 3, 4}, R3::identity, 0, 1}
+        , w0{raytrace::point{8, -3, 0}, R3::pitch(iso::radians{iso::pi / 2}), 2}
+        , w1{raytrace::point{8, -3, 0}, R3::roll(iso::radians{-iso::pi / 2}), 2}
         , column{w0, w1, overlap::type::inclusive}
         , t0{raytrace::point{3, 7, 0.5_p}, 1.4_p, 0.5_p}
         , cb0{raytrace::point{7, -2, 1}, 1, 1, 1} {

--- a/projects/raytrace/demo/world_monochrome4.cpp
+++ b/projects/raytrace/demo/world_monochrome4.cpp
@@ -27,11 +27,11 @@ public:
         , s0{raytrace::point{0, 0, 5}, 5}
         , s1{raytrace::point{0, 0, 15}, 5}
         , s2{raytrace::point{0, 0, 25}, 5}
-        , wall0{raytrace::point{0, 10, 0}, -R3::basis::Y}   // left
-        , wall1{raytrace::point{0, -10, 0}, R3::basis::Y}   // right
-        , wall2{raytrace::point{-10, 0, 0}, R3::basis::X}   // back
-        , wall3{R3::origin, R3::basis::Z}                   // floor
-        , wall4{raytrace::point{0, 0, 160}, -R3::basis::Z}  // ceiling
+        , wall0{raytrace::point{0, 10, 0}, R3::roll(iso::radians{iso::pi / 2})}    // left
+        , wall1{raytrace::point{0, -10, 0}, R3::roll(iso::radians{-iso::pi / 2})}  // right
+        , wall2{raytrace::point{-10, 0, 0}, R3::pitch(iso::radians{iso::pi / 2})}  // back
+        , wall3{}                                                                  // floor
+        , wall4{raytrace::point{0, 0, 160}, R3::pitch(iso::radians{iso::pi})}      // ceiling
     {
         // assign surfaces and materials
         s0.material(&mediums::metals::silver);

--- a/projects/raytrace/demo/world_outrun.cpp
+++ b/projects/raytrace/demo/world_outrun.cpp
@@ -66,7 +66,7 @@ public:
         , sun_center{raytrace::point{0, -3000, 200}}
         , sun_rays{raytrace::vector{0, 200, -200}, colors::white, lights::intensities::radiant}
         , grid{10.0_p, outrun::neon_pink, colors::black}
-        , floor{R3::origin, R3::basis::Z, 1000.0_p, 1000.0_p}
+        , floor{2000.0_p}
         , sun_surface{}
         , sun{sun_center, 600.0_p}
         , s0{raytrace::point{0, 0, 5.0_p}, 5.0_p}

--- a/projects/raytrace/demo/world_planet.cpp
+++ b/projects/raytrace/demo/world_planet.cpp
@@ -19,12 +19,12 @@ public:
         , sun_rays{raytrace::vector{-20, 0, -21}, colors::white, lights::intensities::bright / 2}
         , inner_light{raytrace::point{0, 0, 80}, colors::white, lights::intensities::blinding}
         , center{0, 0, 0}
-        , ringA{center, R3::basis::Z, 10.0_p, 11.8_p}
-        , ringB{center, R3::basis::Z, 12.0_p, 12.2_p}
-        , ringC{center, R3::basis::Z, 12.4_p, 13.2_p}
-        , ringD{center, R3::basis::Z, 14.0_p, 14.2_p}
-        , ringE{center, R3::basis::Z, 14.5_p, 14.7_p}
-        , ringF{center, R3::basis::Z, 15.0_p, 16.7_p}
+        , ringA{center, R3::identity, 10.0_p, 11.8_p}
+        , ringB{center, R3::identity, 12.0_p, 12.2_p}
+        , ringC{center, R3::identity, 12.4_p, 13.2_p}
+        , ringD{center, R3::identity, 14.0_p, 14.2_p}
+        , ringE{center, R3::identity, 14.5_p, 14.7_p}
+        , ringF{center, R3::identity, 15.0_p, 16.7_p}
         , planet{center, 1.0_p}
         , starfield{1024} {
         planet.material(&mediums::metals::stainless);

--- a/projects/raytrace/demo/world_snowman.cpp
+++ b/projects/raytrace/demo/world_snowman.cpp
@@ -53,19 +53,22 @@ public:
         , carrot(colors::orange, mediums::ambient::dim, colors::orange, mediums::smoothness::none,
                  mediums::roughness::tight)
         , plum{colors::plum, mediums::ambient::none, colors::plum, mediums::smoothness::none, mediums::roughness::loose}
-        , ground{raytrace::point{0, 0, 0}, R3::basis::Z}
+        , ground{raytrace::point{0, 0, 0}, R3::identity}
         , sn_btm{raytrace::point{0, 0, 2}, 2.5_p}
         , sn_mid{raytrace::point{0, 0, 5}, 2}
         , sn_top{raytrace::point{0, 0, 7.5_p}, 1.5_p}
         , left_eye{raytrace::point{-0.5_p, 1.1_p, 8}, 0.3_p}
         , right_eye{raytrace::point{0.5_p, 1.1_p, 8}, 0.3_p}
         , nose{raytrace::point{0.0_p, 1.3_p, 7.5_p}, 0.3_p, 1.5_p}
-        , hat_btm{raytrace::point{0, 0, 8.8_p}, R3::vector{{0.0_p, -0.2_p, -1.0_p}}, 0.0_p, 1.5_p}
+        , hat_btm{raytrace::point{0, 0, 8.8_p}, R3::roll(angle(R3::basis::Z, R3::vector{{0.0_p, -0.2_p, -1.0_p}})),
+                  0.0_p, 1.5_p}
         , hat_core{raytrace::point{0.0_p, 0.05_p, 9.05_p}, raytrace::point{0.0_p, 0.4_p, 10.8_p}, 1.0_p}
         , hat_brim{raytrace::point{0.0_p, 0.0_p, 8.8_p}, raytrace::point{0.0_p, 0.05_p, 9.05_p}, 1.5_p}
-        , hat_rim{raytrace::point{0, 0.05_p, 9.05_p}, R3::vector{{0.0_p, 0.2_p, 1.0_p}}, 0.0_p, 1.5_p}
+        , hat_rim{raytrace::point{0, 0.05_p, 9.05_p}, R3::roll(angle(R3::basis::Z, R3::vector{{0.0_p, 0.2_p, 1.0_p}})),
+                  0.0_p, 1.5_p}
         , hat_ribbon{raytrace::point{0, 0.05_p, 9.05_p}, raytrace::point{0, 0.1_p, 9.3_p}, 1.1_p}
-        , hat_top{raytrace::point{0, 0.4_p, 10.8_p}, R3::vector{{0.0_p, 0.2_p, 1.0_p}}, 0.0_p, 1.0_p}
+        , hat_top{raytrace::point{0, 0.4_p, 10.8_p}, R3::roll(angle(R3::basis::Z, R3::vector{{0.0_p, 0.2_p, 1.0_p}})),
+                  0.0_p, 1.0_p}
         , left_arm{raytrace::point{1, 0, 6.5_p}, raytrace::point{4, 0, 5}, 0.2_p}
         , right_arm{raytrace::point{-1, 0, 6.5_p}, raytrace::point{-4, 0, 5}, 0.2_p}
         , left_elbow{raytrace::point{4, 0, 5}, 0.2_p}

--- a/projects/raytrace/demo/world_spheres4.cpp
+++ b/projects/raytrace/demo/world_spheres4.cpp
@@ -16,7 +16,7 @@ public:
         : look_from{0, 50, 20}
         , look_at{0, 0, 10}
         , sun_rays{raytrace::vector{-20, 0, -21}, colors::white, lights::intensities::full}
-        , floor{R3::origin, R3::basis::Z, 100.0_p, 100.0_p}
+        , floor{200.0_p}
         , cb0{0.125_p, colors::black, colors::white}
         , s0{raytrace::point{5.0_p, 0, 5}, 5.0_p}
         , s1{raytrace::point{-5.0_p, 0, 5}, 5.0_p}

--- a/projects/raytrace/include/raytrace/configuration.hpp
+++ b/projects/raytrace/include/raytrace/configuration.hpp
@@ -23,9 +23,11 @@ static constexpr bool scene{false};
 /// Enables debug for the objparser calls
 static constexpr bool objparser{false};
 /// Enables debug for the polygon
-static constexpr bool polygon{false};
+static constexpr bool polygon{true};
 /// Enables debug for the model loader
 static constexpr bool model{false};
+/// Enables debug for bounding object creation
+static constexpr bool bounds{false};
 }  // namespace debug
 
 /// Enforces range checking on some calls

--- a/projects/raytrace/include/raytrace/entity.hpp
+++ b/projects/raytrace/include/raytrace/entity.hpp
@@ -117,10 +117,7 @@ public:
     /// This is the roll, pitch, yaw order.
     /// @warning This may result in a non-unique rotation!
     void rotation(iso::radians xr, iso::radians yr, iso::radians zr) {
-        matrix Rx = geometry::rotation(R3::basis::X, xr);
-        matrix Ry = geometry::rotation(R3::basis::Y, yr);
-        matrix Rz = geometry::rotation(R3::basis::Z, zr);
-        m_rotation = (Rz * Ry) * Rx;
+        m_rotation = geometry::rotation(zr, yr, xr);
         // this is used to rotate vectors back into object space.
         m_inv_rotation = m_rotation.inverse();
         compute_transforms();
@@ -134,7 +131,8 @@ public:
         iso::convert(x_r, x);
         iso::convert(y_r, y);
         iso::convert(z_r, z);
-        rotation(x_r, y_r, z_r);
+        // "this" is used so we are clear that we are not calling the geometry::rotation
+        this->rotation(x_r, y_r, z_r);
     }
 
     /// Finds the point in world space given the object point

--- a/projects/raytrace/include/raytrace/mapping.hpp
+++ b/projects/raytrace/include/raytrace/mapping.hpp
@@ -8,7 +8,7 @@
 namespace raytrace {
 
 namespace mapping {
-/// Defines function pointer to a R3=>R2 reducing mapping function
+/// Defines functor to a R3=>R2 reducing mapping function
 using reducer = std::function<geometry::R2::point(geometry::R3::point const&)>;
 
 /// Normalizes the R3 point to a unit sphere while converting to R2 coordinates on the surface of the sphere
@@ -19,7 +19,7 @@ geometry::R2::point spherical(geometry::R3::point const& p);
 /// @note Values are in unit TURNS not RADS
 geometry::R2::point spherical(geometry::R3::vector const& q);
 
-/// Maps on to an ideal cylinderical fields along the Z axis
+/// Maps on to an ideal cylindrical fields along the Z axis
 /// @param scale The Z height scale size
 /// @note Use std::bind(scale, _1) to fix a certain scale height when creating a mapper
 geometry::R2::point cylindrical(precision scale, geometry::R3::point const& p);
@@ -39,7 +39,7 @@ geometry::R2::point toroidal(precision r1, geometry::R3::point const& p);
 geometry::R2::point planar_polar(raytrace::vector const& N, raytrace::vector const& X, raytrace::point const& C,
                                  geometry::R3::point const& p);
 
-/// Defines a method which can map a value within a unit range given a integer ratio, to a 3D surface
+/// Defines a functor which can map a value within a unit range given a integer ratio, to a 3D surface
 using expander = std::function<geometry::R3::point(size_t const numerator, size_t const denominator)>;
 
 /// Uses the golden ratio to map a range (from an integer ratio) to a point on a unit sphere

--- a/projects/raytrace/include/raytrace/mediums/medium.hpp
+++ b/projects/raytrace/include/raytrace/mediums/medium.hpp
@@ -111,10 +111,13 @@ protected:
     precision m_transmissivity;
     /// This material's refractive index
     precision m_refractive_index;
-    /// Electrical Permissivity
+
+    // Electrical Permissivity
     // precision m_permissivity;
-    /// Magnetic Permeability
+
+    // Magnetic Permeability
     // precision m_permeability;
+
     /// The mapping reduction function (if supplied) maps R3 to R2 for "surface mapping"
     mapping::reducer m_reducing_map;
 };

--- a/projects/raytrace/include/raytrace/objects/plane.hpp
+++ b/projects/raytrace/include/raytrace/objects/plane.hpp
@@ -8,18 +8,17 @@
 namespace raytrace {
 namespace objects {
 /// Constructs a 1 sided infinite plane
-class plane
-    : public geometry::plane
-    , public object {
+class plane : public object {
 public:
-    /// Constructs a plane from a point and a normal
-    plane(point const& point, vector const& normal);
-    /// Constructs a plane from a point and a normal (z_unit) and a x_unit vector which defines the plane's orientation
-    /// in space
-    /// @param axes The basis for the the plane. The normal will be pulled from the Z (applicate) vector. The origin
-    /// will be pulled from the axis origin.
-    plane(axes const& axes);
+    /// Constructs a plane with the default orientation
+    /// The plane is idealized as the XY plane with the normal as +Z.
+    plane();
 
+    /// Constructs a plane from a point (translation) and a rotation matrix
+    /// The plane is idealized as the XY plane with the normal as +Z.
+    plane(point const& point, matrix const& rotation);
+
+    /// Destructor
     virtual ~plane() = default;
 
     // ┌─────────────────────────┐
@@ -33,7 +32,6 @@ public:
     bool is_along_infinite_extent(ray const& ray) const override;
 
 protected:
-    R3::axes m_basis;  ///< The unit axes of the plane in world coordinates
     vector normal_(point const& object_surface_point) const override;
 };
 }  // namespace objects

--- a/projects/raytrace/include/raytrace/objects/polygon.hpp
+++ b/projects/raytrace/include/raytrace/objects/polygon.hpp
@@ -7,10 +7,9 @@
 
 namespace raytrace {
 namespace objects {
-/// A three point polygon which uses the convex "inner" rules to find the intersection
-/// and not the plane intersection rules
+/// A three point polygon which uses the plane intersection rules then the convex "inner" rules to find the intersection
 template <size_t N>
-class polygon : public plane {
+class polygon : public object {
 public:
     /// Constructs a polygon from some number of points (where N >=3)
     /// The second point is considered the middle point for computation of the normal.
@@ -25,6 +24,7 @@ public:
     /// of the given points. All the points will be adjusted so that the center is at the R3::origin and the
     /// entire polygon has been translated by the centroid
     polygon(std::array<R3::point, N> const& points);
+    /// Destructors
     virtual ~polygon() = default;
 
     // ┌─────────────────────────┐
@@ -34,15 +34,17 @@ public:
     bool is_surface_point(point const& world_point) const override;
     precision get_object_extent(void) const override;
     void print(std::ostream& os, char const str[]) const override;
+    image::point map(point const& object_surface_point) const override;
 
     /// Determines if a point on the plane is contained within the array of three points
     bool is_contained(point const& object_point) const;
 
-    /// Returns a read-only reference to an array of 3 points
+    /// Returns a read-only reference to an array of N points
     const std::array<R3::point, N>& points() const;
 
 protected:
     std::array<R3::point, N> m_points;
+    R3::vector normal_(point const& object_surface_point) const override;
     /// The squared maximum radius from object center.
     precision m_radius2;
 };
@@ -64,9 +66,5 @@ std::array<raytrace::point, N> make_polygon_points(precision radius, R3::point c
 }
 
 }  // namespace objects
-
-/// Returns the plane in which the three points are co-planar
-template <size_t N>
-geometry::plane as_plane(objects::polygon<N> const& poly);
 
 }  // namespace raytrace

--- a/projects/raytrace/include/raytrace/objects/ring.hpp
+++ b/projects/raytrace/include/raytrace/objects/ring.hpp
@@ -9,8 +9,21 @@ namespace objects {
 /// A plane bounded by an inner and outer radius
 class ring : public raytrace::objects::plane {
 public:
+    /// Constructs a ring at the default location
+    /// The ring is idealized as the XY plane with the normal as +Z.
+    /// @param inner The inner radius of the ring in object space
+    /// @param outer The outer radius of the ring in object space
+    ring(precision inner, precision outer);
+
     /// Constructs a ring
-    ring(point const& C, vector const& N, precision inner, precision outer);
+    /// The ring is idealized as the XY plane with the normal as +Z.
+    /// @param C The center of the ring in world space
+    /// @param R The rotation matrix of the ring in world space
+    /// @param inner The inner radius of the ring in object space
+    /// @param outer The outer radius of the ring in object space
+    ring(point const& C, matrix const& R, precision inner, precision outer);
+
+    /// Destructor
     virtual ~ring() = default;
 
     // ┌─────────────────────────┐
@@ -26,7 +39,4 @@ private:
     precision m_outer_radius2;  ///< Squared Outer Radius
 };
 }  // namespace objects
-/// Returns the plane in which the three points we co-planar
-geometry::plane as_plane(objects::ring const& tri);
-
 }  // namespace raytrace

--- a/projects/raytrace/include/raytrace/objects/square.hpp
+++ b/projects/raytrace/include/raytrace/objects/square.hpp
@@ -9,9 +9,14 @@ namespace objects {
 /// A square limit on a plane
 class square : public plane {
 public:
-    /// Constructs a square from two half width/heights and a normal
-    square(point const& C, raytrace::vector const& N, precision half_height, precision half_width);
-    square(R3::axes const& A, precision half_height, precision half_width);
+    /// Constructs a square in the default orientation
+    /// Since it is a square, the sides will be the same.
+    square(precision side);
+
+    /// Constructs a square from a point, a rotation and the length of a side
+    /// Since it is a square, the sides will be the same.
+    square(point const& C, matrix const& rotation, precision side);
+
     virtual ~square() = default;
 
     // ┌─────────────────────────┐
@@ -24,8 +29,8 @@ public:
     void print(std::ostream& os, char const str[]) const override;
 
 private:
-    /// these points assume a 2D mapping in the plane itself.
-    std::array<raytrace::point, 2> m_points;
+    image::point min_;
+    image::point max_;
 };
 }  // namespace objects
 /// Returns the plane in which the three points we co-planar

--- a/projects/raytrace/include/raytrace/objects/wall.hpp
+++ b/projects/raytrace/include/raytrace/objects/wall.hpp
@@ -10,8 +10,13 @@ namespace objects {
 /// A pair of opposing planes with a thickness
 class wall : public object {
 public:
-    /// Constructs a sphere at a point of a given radius.
-    wall(point const& center, vector const& normal, precision thickness);
+    /// Constructs a wall (a pair of planes facing opposite directions) at the default location of a given thickness.
+    wall(precision thickness);
+
+    /// Constructs a wall (a pair of planes facing opposite directions) at given location and orientation of a given
+    /// thickness.
+    wall(point const& center, matrix const& rotation, precision thickness);
+    /// Destructor
     virtual ~wall() = default;
 
     // ┌─────────────────────────┐

--- a/projects/raytrace/source/objects/face.cpp
+++ b/projects/raytrace/source/objects/face.cpp
@@ -6,13 +6,15 @@ namespace objects {
 face::face(point const& A, point const& B, point const& C)
     : polygon({A, B, C})
     , m_texture_coords{image::point{1, 0}, image::point{0, 0}, image::point{0, 1}}
-    , m_normals{m_normal, m_normal, m_normal} {
+    , m_normals{polygon<3>::normal_(R3::origin), polygon<3>::normal_(R3::origin), polygon<3>::normal_(R3::origin)} {
     m_type = Type::Face;
 }
 
 face::face(point const& A, point const& B, point const& C, image::point const& a, image::point const& b,
            image::point const& c)
-    : polygon({A, B, C}), m_texture_coords{a, b, c}, m_normals{m_normal, m_normal, m_normal} {
+    : polygon({A, B, C})
+    , m_texture_coords{a, b, c}
+    , m_normals{polygon<3>::normal_(A), polygon<3>::normal_(B), polygon<3>::normal_(C)} {
 }
 
 face::face(point const& A, point const& B, point const& C, image::point const& a, image::point const& b,
@@ -25,8 +27,8 @@ hits face::collisions_along(ray const& object_ray) const {
 }
 
 void face::print(std::ostream& os, char const str[]) const {
-    os << str << " Face @" << this << " " << position() << " Normal " << unormal() << " A=" << m_points[0]
-       << " B=" << m_points[1] << " C=" << m_points[2] << std::endl;
+    os << str << " Face @" << this << " " << position() << " A=" << m_points[0] << " B=" << m_points[1]
+       << " C=" << m_points[2] << " normal " << normal_(m_points[0]) << std::endl;
 }
 
 bool face::is_surface_point(point const& world_point) const {

--- a/projects/raytrace/source/objects/ring.cpp
+++ b/projects/raytrace/source/objects/ring.cpp
@@ -10,10 +10,12 @@ using namespace linalg::operators;
 using namespace geometry;
 using namespace geometry::operators;
 
-ring::ring(point const& C, vector const& N, precision inner, precision outer)
-    : raytrace::objects::plane(C, N), m_inner_radius2(inner * inner), m_outer_radius2(outer * outer) {
+ring::ring(precision inner, precision outer) : ring(R3::origin, R3::identity, inner, outer) {
+}
+
+ring::ring(point const& C, matrix const& R, precision inner, precision outer)
+    : raytrace::objects::plane(C, R), m_inner_radius2(inner * inner), m_outer_radius2(outer * outer) {
     m_type = Type::Ring;
-    m_has_definite_volume = false;  // a ring is a bounded planar surface
     basal::exception::throw_unless(m_inner_radius2 < m_outer_radius2, __FILE__, __LINE__,
                                    "Inner radius must be less than outer radius");
 }
@@ -21,7 +23,7 @@ ring::ring(point const& C, vector const& N, precision inner, precision outer)
 hits ring::collisions_along(ray const& object_ray) const {
     hits ts;
     // is the ray parallel to the plane?
-    vector const& N = unormal().normalized();
+    vector const& N = normal_(R3::origin);  // same as plane()
     vector const& V = object_ray.direction();
     precision const proj = dot(V, N);                     // if so the projection is zero
     if (not basal::nearly_zero(proj) and proj < 0.0_p) {  // they collide *somewhere*
@@ -53,8 +55,8 @@ bool ring::is_surface_point(point const& world_point) const {
 }
 
 void ring::print(std::ostream& os, char const str[]) const {
-    os << str << " ring @" << this << " " << object_<3>::position() << " " << m_normal
-       << " Radii (Squared):" << m_inner_radius2 << ", " << m_outer_radius2 << std::endl;
+    os << str << " ring @" << this << " " << object_<3>::position() << " Radii (Squared):" << m_inner_radius2 << ", "
+       << m_outer_radius2 << std::endl;
 }
 
 precision ring::get_object_extent(void) const {

--- a/projects/raytrace/source/objects/square.cpp
+++ b/projects/raytrace/source/objects/square.cpp
@@ -10,25 +10,19 @@ using namespace linalg::operators;
 using namespace geometry;
 using namespace geometry::operators;
 
-square::square(point const& C, vector const& N, precision hh, precision hw)
-    : raytrace::objects::plane(C, N), m_points{} {
-    m_type = Type::Square;
-    m_has_definite_volume = false;  // a square is a bounded planar surface
-    m_points[0] = raytrace::point{-hw, -hh, 0};
-    m_points[1] = raytrace::point{+hw, +hh, 0};
+square::square(precision side) : square(R3::origin, R3::identity, side) {
 }
 
-square::square(R3::axes const& A, precision hh, precision hw) : raytrace::objects::plane(A), m_points{} {
+square::square(point const& C, matrix const& R, precision S)
+    : raytrace::objects::plane(C, R), min_{-S / 2, -S / 2}, max_{S / 2, S / 2} {
     m_type = Type::Square;
     m_has_definite_volume = false;  // a square is a bounded planar surface
-    m_points[0] = raytrace::point{-hw, -hh, 0};
-    m_points[1] = raytrace::point{+hw, +hh, 0};
 }
 
 hits square::collisions_along(ray const& object_ray) const {
     hits ts;
     // is the ray parallel to the plane?
-    vector const& N = unormal().normalized();
+    vector const& N = R3::basis::Z;  // same as plane()
     vector const& V = object_ray.direction();
     precision proj = dot(V, N);
     // if so the projection is not zero they collide *somewhere*
@@ -42,11 +36,8 @@ hits square::collisions_along(ray const& object_ray) const {
         precision const t = dot(C, N) / proj;
         point D = object_ray.distance_along(t);
         // get the transform matrix from object space to plane space
-        // transform D to the plane space and check if it's within the 2D points
-        R3::point PD = m_basis.to_basis() * D;
         // if point D is contained within the 3D points it's in the square.
-        if (linalg::within_inclusive(m_points[0].x, PD.x, m_points[1].x)
-            and linalg::within_inclusive(m_points[0].y, PD.y, m_points[1].y)) {
+        if (linalg::within_inclusive(min_.x, D.x, max_.x) and linalg::within_inclusive(min_.y, D.y, max_.y)) {
             ts.emplace_back(intersection{D}, t, normal_(D), this);
         }
     }
@@ -61,29 +52,24 @@ bool square::is_surface_point(point const& world_point) const {
     // now convert the world point to an object point
     // and check if it's within the 2D points
     point object_point = reverse_transform(world_point);
-    matrix const& M = m_basis.to_basis();
-    point plane_point = M * object_point;
-    return linalg::within_inclusive(m_points[0].x, plane_point.x, m_points[1].x)
-           and linalg::within_inclusive(m_points[0].y, plane_point.y, m_points[1].y);
+    return linalg::within_inclusive(min_.x, object_point.x, max_.x)
+           and linalg::within_inclusive(min_.y, object_point.y, max_.y);
 }
 
 void square::print(std::ostream& os, char const name[]) const {
-    os << "square @ " << this << " " << name << " " << position() << " " << m_normal << " from " << m_points[0]
-       << " to " << m_points[1] << std::endl;
+    os << "square @ " << this << " " << name << " " << position() << " from " << min_ << " to " << max_ << std::endl;
 }
 
 image::point square::map(point const& object_surface_point) const {
-    // use the m_basis to map the object_surface_point to the UV space
-    matrix const& M = m_basis.to_basis();
-    R3::point uv_point = M * object_surface_point;
     // scale the UV point to the surface scale
     // ensure the UV point is within the range of 0 to 1
-    image::point scaled_point = image::point(uv_point.x * m_surface_scale.u, uv_point.y * m_surface_scale.v);
-    return scaled_point;
+    image::point uv
+        = image::point(object_surface_point.x * m_surface_scale.u, object_surface_point.y * m_surface_scale.v);
+    return uv;
 }
 
 precision square::get_object_extent(void) const {
-    return (m_points[1] - R3::origin).magnitude();
+    return (max_ - R3::origin).magnitude();
 }
 
 }  // namespace objects

--- a/projects/raytrace/test/gtest_face.cpp
+++ b/projects/raytrace/test/gtest_face.cpp
@@ -18,7 +18,6 @@ TEST(FaceTest, Basics) {
     f.print(std::cout, "Face");
     EXPECT_EQ(f.points().size(), 3u);
     EXPECT_POINT_EQ(raytrace::point(1.0_p / 3.0_p, 1.0_p / 3.0_p, 0.0_p / 3.0_p), f.position());
-    raytrace::vector n = f.normal(D);
     EXPECT_VECTOR_EQ(R3::basis::Z, f.normal(D));
     image::point p = f.map(R3::origin);
     EXPECT_PRECISION_EQ(p[0], 1.0_p / 3.0_p);
@@ -36,7 +35,6 @@ TEST(FaceTest, Texture) {
     raytrace::objects::face f{A, B, C, image::point{1, 0}, image::point{0, 0}, image::point{0, 1}};
     f.print(std::cout, "Face");
     EXPECT_EQ(f.points().size(), 3u);
-    raytrace::vector n = f.normal(D);
     EXPECT_VECTOR_EQ(R3::basis::Z, f.normal(D));
     image::point p = f.map(D);
     // FIXME uv mapping needs to be verified, but this is not helpful

--- a/projects/raytrace/test/gtest_light.cpp
+++ b/projects/raytrace/test/gtest_light.cpp
@@ -49,7 +49,7 @@ TEST(LightTest, BeamLightColor) {
 
 TEST(LightTest, DISABLED_TriColorSpots) {
     raytrace::objects::sphere shape(raytrace::point{0, 0, 3}, 3);
-    raytrace::objects::plane floor(raytrace::point{0, 0, 0}, R3::basis::Z);
+    raytrace::objects::plane floor;
     raytrace::point p0{10, 0, 50};
     raytrace::matrix rot120 = rotation(R3::basis::Z, iso::radians(2 * iso::pi / 3));
     raytrace::point p1 = rot120 * p0;
@@ -71,8 +71,8 @@ TEST(LightTest, DISABLED_TriColorSpots) {
 
 TEST(LightTest, DISABLED_BulbTest) {
     raytrace::objects::sphere shape(raytrace::point{0, 0, 3}, 3);
-    raytrace::objects::plane floor(raytrace::point{0, 0, 0}, R3::basis::Z);
-    raytrace::lights::bulb light(raytrace::point{0, 0, 9}, 0.2_p, colors::white, lights::intensities::blinding, 100);
+    raytrace::objects::plane floor;
+    raytrace::lights::bulb light(raytrace::point{0, 0, 9}, 0.2_p, colors::white, lights::intensities::intense, 16);
     raytrace::scene scene;
     raytrace::camera view(480, 640, iso::degrees(55));
     view.move_to(raytrace::point{30, 30, 30}, raytrace::point{29, 29, 29});

--- a/projects/raytrace/test/gtest_perf.cpp
+++ b/projects/raytrace/test/gtest_perf.cpp
@@ -43,7 +43,7 @@ protected:
 
 TEST_F(PerfCounter, IntersectionsPlane) {
     raytrace::ray r{raytrace::point{0, 0, 2}, -R3::basis::Z};
-    raytrace::objects::plane obj(R3::origin, R3::basis::Z);
+    raytrace::objects::plane obj;
     activity = std::string("plane intersections");
     for (size_t count = 0; count < number_of_ops; count++) {
         geometry::intersection hit = obj.intersect(r).intersect;
@@ -53,7 +53,7 @@ TEST_F(PerfCounter, IntersectionsPlane) {
 
 TEST_F(PerfCounter, IntersectionsSquare) {
     raytrace::ray r{raytrace::point{0.98_p, 0.98_p, 2}, -R3::basis::Z};
-    raytrace::objects::square obj(R3::origin, R3::basis::Z, 1.0_p, 1.0_p);
+    raytrace::objects::square obj(2.0_p);
     activity = std::string("square intersections");
     for (size_t count = 0; count < number_of_ops; count++) {
         geometry::intersection hit = obj.intersect(r).intersect;
@@ -63,7 +63,7 @@ TEST_F(PerfCounter, IntersectionsSquare) {
 
 TEST_F(PerfCounter, IntersectionsRing) {
     raytrace::ray r{raytrace::point{1.5_p, 0, 2}, -R3::basis::Z};
-    raytrace::objects::ring obj(R3::origin, R3::basis::Z, 1.0_p, 2.0_p);
+    raytrace::objects::ring obj(1.0_p, 2.0_p);
     activity = std::string("ring intersections");
     for (size_t count = 0; count < number_of_ops; count++) {
         geometry::intersection hit = obj.intersect(r).intersect;

--- a/projects/raytrace/test/gtest_plane.cpp
+++ b/projects/raytrace/test/gtest_plane.cpp
@@ -13,20 +13,8 @@ TEST(PlaneTest, Type) {
     using namespace raytrace;
     using namespace raytrace::objects;
 
-    raytrace::objects::plane PL{R3::origin, R3::basis::Z};
+    raytrace::objects::plane PL{};
     ASSERT_EQ(PL.get_type(), raytrace::objects::Type::Plane);
-}
-
-TEST(PlaneTest, AxesConstructor) {
-    using namespace raytrace;
-    using namespace raytrace::objects;
-
-    R3::axes a{R3::point{0, 0, 0}, R3::basis::X, R3::basis::Y, R3::basis::Z};
-    raytrace::objects::plane PL{a};
-    ASSERT_EQ(PL.get_type(), raytrace::objects::Type::Plane);
-    ASSERT_POINT_EQ(R3::origin, PL.position());
-    ASSERT_VECTOR_EQ(R3::basis::Z, PL.unormal());
-    ASSERT_POINT_EQ(PL.center(), PL.position());
 }
 
 TEST(PlaneTest, Position) {
@@ -34,7 +22,7 @@ TEST(PlaneTest, Position) {
     using namespace raytrace::objects;
 
     raytrace::point C{14, -18, -1};
-    raytrace::objects::plane PL{C, R3::basis::Z};
+    raytrace::objects::plane PL{C, R3::identity};
 
     ASSERT_POINT_EQ(C, PL.position());
     raytrace::point D{-3, -3, 19};
@@ -48,7 +36,7 @@ TEST(PlaneTest, OnSurface) {
     using namespace raytrace::objects;
 
     raytrace::point C{0, 0, -1};
-    raytrace::objects::plane PL{C, R3::basis::Z};
+    raytrace::objects::plane PL{C, R3::identity};
     ASSERT_TRUE(PL.is_surface_point(raytrace::point{0, 0, -1}));
     ASSERT_TRUE(PL.is_surface_point(raytrace::point{1, 1, -1}));
     ASSERT_FALSE(PL.is_surface_point(raytrace::point{0, 0, 1}));
@@ -59,14 +47,13 @@ TEST(PlaneTest, Intersections) {
     using namespace raytrace::objects;
 
     raytrace::point C{0, 0, -1};
-    raytrace::objects::plane PL{C, R3::basis::Z};
+    raytrace::objects::plane PL{C, R3::identity};
 
     raytrace::ray r0{raytrace::point{1, 1, 1}, vector{{1, 1, 1}}.normalized()};
     raytrace::ray r1{raytrace::point{1, 1, 1}, vector{{-1, -1, -1}}.normalized()};
     raytrace::point A{-1, -1, -1};  // in the plane
     ray r2{C, R3::basis::Z};
     ray r3{C, -R3::basis::Z};
-    ASSERT_POINT_EQ(PL.center(), PL.position());
 
     geometry::intersection ir0PL = PL.intersect(r0).intersect;
     ASSERT_EQ(geometry::IntersectionType::None, get_type(ir0PL));
@@ -88,16 +75,13 @@ TEST(PlaneTest, SandwichRays) {
     using namespace raytrace;
     using namespace raytrace::objects;
 
-    raytrace::objects::plane P0{raytrace::point{0, 0, 10}, vector{{0, 0, -1}}};
-    raytrace::objects::plane P1{raytrace::point{0, 0, -10}, vector{{0, 0, 1}}};
+    raytrace::objects::plane P0{raytrace::point{0, 0, 10}, R3::roll(0.5)};
+    raytrace::objects::plane P1{raytrace::point{0, 0, -10}, R3::identity};
     ray r0{raytrace::point{0, 0, 0}, vector{{1, 0, 1}}.normalized()};
     ray r1{raytrace::point{0, 0, 0}, vector{{1, 0, -1}}.normalized()};
 
     raytrace::point p0{10, 0, 10};
     raytrace::point p1{10, 0, -10};
-
-    ASSERT_POINT_EQ(P0.center(), P0.position());
-    ASSERT_POINT_EQ(P1.center(), P1.position());
 
     geometry::intersection ir0P0 = P0.intersect(r0).intersect;
     ASSERT_EQ(geometry::IntersectionType::Point, get_type(ir0P0));
@@ -118,12 +102,8 @@ TEST(PlaneTest, ScaleRotateTranslate) {
     using namespace raytrace;
     using namespace raytrace::objects;
     raytrace::point C{7, 7, 7};
-    raytrace::objects::plane P0{C, geometry::R3::basis::X};
-    P0.rotation(iso::degrees{0.0_p}, iso::degrees{0.0_p}, iso::degrees{180.0_p});
-    vector const& should_be_negative_X = P0.normal(C);
-    vector const negative_X = -geometry::R3::basis::X;
-    ASSERT_EQ(negative_X.dimensions, 3ul);
-    ASSERT_VECTOR_EQ(negative_X, should_be_negative_X);
+    raytrace::objects::plane P0{C, R3::pitch(0.25)};
+    ASSERT_VECTOR_EQ(R3::basis::X, P0.normal(C));
     {
         raytrace::ray const world_ray{geometry::R3::origin, geometry::R3::basis::X};
         auto inter = P0.intersect(world_ray).intersect;
@@ -140,7 +120,7 @@ TEST(PlaneTest, ScaleRotateTranslate) {
 TEST(PlaneTest, Mapping) {
     using namespace raytrace;
     using namespace raytrace::objects;
-    raytrace::objects::plane P0{R3::origin, R3::basis::Z};
+    raytrace::objects::plane P0;
     P0.set_surface_scale(1.0_p, 1.0_p);
     precision r = 1.0_p;
     {

--- a/projects/raytrace/test/gtest_polygon.cpp
+++ b/projects/raytrace/test/gtest_polygon.cpp
@@ -18,7 +18,8 @@ TEST(TriangleTest, Basic) {
     raytrace::objects::triangle shape{{A, B, C}};
     ASSERT_EQ(shape.get_type(), raytrace::objects::Type::Polygon);
     ASSERT_POINT_EQ(raytrace::point(0.0_p / 3.0_p, 2.0_p / 3.0_p, 0.0_p / 3.0_p), shape.position());
-    ASSERT_TRUE(shape.is_contained(raytrace::point{0.0_p, 0.25_p, 0.0_p}));
+    ASSERT_TRUE(shape.is_contained(raytrace::point{0.0_p, 0.25_p, 0.0_p}))
+        << "Point must be in _object space_, not world space";
     auto displacement = raytrace::point{1, 1, 0} - raytrace::point{0, 2.0_p / 3.0_p, 0};
     ASSERT_PRECISION_EQ(displacement.magnitude(), shape.get_object_extent());
     ASSERT_POINT_EQ(R3::basis::Z, shape.normal(raytrace::point{0.0_p, 0.25_p, 0.0_p}));
@@ -29,12 +30,10 @@ TEST(TriangleTest, PlaneParallelTriangle) {
     raytrace::point B{1.0_p, 1.0_p, 0.0_p};
     raytrace::point C{-1.0_p, 1.0_p, 0.0_p};
     raytrace::objects::triangle D{A, B, C};
-    geometry::plane E = as_plane(D);
-    vector F{{0.0_p, 0.0_p, 1.0_p}};  // +Z
-    vector G = E.unormal();
+    vector G = D.normal(R3::origin);
 
     using namespace linalg::operators;
-    ASSERT_TRUE(G || F);
+    ASSERT_TRUE(G || R3::basis::Z);
 }
 
 TEST(TriangleTest, RayIntersection) {

--- a/projects/raytrace/test/gtest_ring.cpp
+++ b/projects/raytrace/test/gtest_ring.cpp
@@ -13,7 +13,7 @@ TEST(RingTest, Type) {
     using namespace raytrace;
     using namespace raytrace::objects;
 
-    ring R{R3::origin, R3::basis::Z, 1.0_p, 2.0_p};
+    ring R{1.0_p, 2.0_p};
     ASSERT_EQ(R.get_type(), Type::Ring);
 }
 
@@ -23,7 +23,7 @@ TEST(RingTest, RayIntersectionAtOrigin) {
 
     raytrace::point C{0, 0, 0};
     vector N{{0, 0, 1}};
-    ring R{C, N, 0.1_p, 10.0_p};
+    ring R{0.1_p, 10.0_p};
 
     ray r0{raytrace::point{0.5_p, 0.5_p, 1}, vector{{0, 0, -1}}};
 
@@ -55,7 +55,7 @@ TEST(RingTest, RayIntersectionAwayFromOrigin) {
 
     raytrace::point C{60, -50, 42};
     vector N{R3::basis::X};
-    ring R{C, N, 4.0_p, 10.0_p};
+    ring R{C, R3::pitch(0.25), 4.0_p, 10.0_p};
     ASSERT_POINT_EQ(C, R.position());
     ASSERT_VECTOR_EQ(N, R.normal(C));
 

--- a/projects/raytrace/test/gtest_square.cpp
+++ b/projects/raytrace/test/gtest_square.cpp
@@ -13,20 +13,8 @@ TEST(SquareTest, Type) {
     using namespace raytrace;
     using namespace raytrace::objects;
 
-    raytrace::objects::square SQ{R3::origin, R3::basis::Z, 10, 10};
+    raytrace::objects::square SQ{20};
     ASSERT_EQ(SQ.get_type(), raytrace::objects::Type::Square);
-}
-
-TEST(SquareTest, AxesConstructor) {
-    using namespace raytrace;
-    using namespace raytrace::objects;
-
-    R3::axes a{R3::point{0, 0, 0}, R3::basis::X, R3::basis::Y, R3::basis::Z};
-    raytrace::objects::square SQ{a, 10, 10};
-    ASSERT_EQ(SQ.get_type(), raytrace::objects::Type::Square);
-    ASSERT_POINT_EQ(R3::origin, SQ.position());
-    ASSERT_VECTOR_EQ(R3::basis::Z, SQ.unormal());
-    ASSERT_POINT_EQ(SQ.center(), SQ.position());
 }
 
 TEST(SquareTest, Position) {
@@ -34,7 +22,7 @@ TEST(SquareTest, Position) {
     using namespace raytrace::objects;
 
     raytrace::point C{14, -18, -1};
-    raytrace::objects::square SQ{C, R3::basis::Z, 10, 10};
+    raytrace::objects::square SQ{C, R3::identity, 20};
 
     ASSERT_POINT_EQ(C, SQ.position());
     raytrace::point D{-3, -3, 19};
@@ -48,7 +36,7 @@ TEST(SquareTest, OnSurface) {
     using namespace raytrace::objects;
 
     raytrace::point C{0, 0, -1};
-    raytrace::objects::square SQ{C, R3::basis::Z, 10, 10};
+    raytrace::objects::square SQ{C, R3::identity, 20};
     ASSERT_TRUE(SQ.is_surface_point(raytrace::point{0, 0, -1}));
     ASSERT_TRUE(SQ.is_surface_point(raytrace::point{1, 1, -1}));
     ASSERT_FALSE(SQ.is_surface_point(raytrace::point{0, 0, 1}));
@@ -60,14 +48,13 @@ TEST(SquareTest, Intersections) {
     using namespace raytrace::objects;
 
     raytrace::point C{0, 0, -1};
-    raytrace::objects::square SQ{C, R3::basis::Z, 10, 10};
+    raytrace::objects::square SQ{C, R3::identity, 20};
 
     raytrace::ray r0{raytrace::point{1, 1, 1}, vector{{1, 1, 1}}.normalized()};
     raytrace::ray r1{raytrace::point{1, 1, 1}, vector{{-1, -1, -1}}.normalized()};
     raytrace::point A{-1, -1, -1};  // in the plane?
     ray r2{C, R3::basis::Z};
     ray r3{C, -R3::basis::Z};
-    ASSERT_POINT_EQ(SQ.center(), SQ.position());
 
     geometry::intersection ir0PL = SQ.intersect(r0).intersect;
     ASSERT_EQ(geometry::IntersectionType::None, get_type(ir0PL));
@@ -94,8 +81,7 @@ TEST(SquareTest, Intersection2) {
     using namespace raytrace;
     using namespace raytrace::objects;
 
-    raytrace::objects::square SQ{raytrace::point{0, 5, 5}, -R3::basis::Y, 10, 10};
-    ASSERT_POINT_EQ(SQ.center(), SQ.position());
+    raytrace::objects::square SQ{raytrace::point{0, 5, 5}, R3::roll(0.25), 20};
 
     {
         raytrace::ray r0{raytrace::point{0, 0, 5}, vector{{0, 1, 0}}.normalized()};
@@ -121,8 +107,7 @@ TEST(SquareTest, Intersection3) {
     using namespace raytrace;
     using namespace raytrace::objects;
 
-    raytrace::objects::square SQ{raytrace::point{0, 0, 10}, -R3::basis::Z, 10, 10};
-    ASSERT_POINT_EQ(SQ.center(), SQ.position());
+    raytrace::objects::square SQ{raytrace::point{0, 0, 10}, R3::pitch(-0.5), 20};
 
     {
         raytrace::ray r0{raytrace::point{0, 0, 5}, R3::basis::Z};
@@ -148,16 +133,13 @@ TEST(SquareTest, SandwichRays) {
     using namespace raytrace;
     using namespace raytrace::objects;
 
-    raytrace::objects::square SQ0{raytrace::point{0, 0, 10}, vector{{0, 0, -1}}, 10, 10};
-    raytrace::objects::square SQ1{raytrace::point{0, 0, -10}, vector{{0, 0, 1}}, 10, 10};
+    raytrace::objects::square SQ0{raytrace::point{0, 0, 10}, R3::pitch(-0.5), 20};
+    raytrace::objects::square SQ1{raytrace::point{0, 0, -10}, R3::identity, 20};
     ray r0{raytrace::point{0, 0, 0}, vector{{1, 0, 1}}.normalized()};
     ray r1{raytrace::point{0, 0, 0}, vector{{1, 0, -1}}.normalized()};
 
     raytrace::point p0{10, 0, 10};
     raytrace::point p1{10, 0, -10};
-
-    ASSERT_POINT_EQ(SQ0.center(), SQ0.position());
-    ASSERT_POINT_EQ(SQ1.center(), SQ1.position());
 
     geometry::intersection ir0P0 = SQ0.intersect(r0).intersect;
     ASSERT_EQ(geometry::IntersectionType::Point, get_type(ir0P0));
@@ -178,13 +160,12 @@ TEST(SquareTest, ScaleRotateTranslate) {
     using namespace raytrace;
     using namespace raytrace::objects;
     raytrace::point C{7, 7, 7};
-    raytrace::objects::square SQ{C, geometry::R3::basis::X, 10, 10};
-    ASSERT_POINT_EQ(SQ.center(), SQ.position());
-    SQ.rotation(iso::degrees{0.0_p}, iso::degrees{0.0_p}, iso::degrees{180.0_p});
-    vector const& should_be_negative_X = SQ.normal(C);
+
+    raytrace::objects::square SQ{C, R3::pitch(-0.25), 20.0_p};
     vector const negative_X = -geometry::R3::basis::X;
     ASSERT_EQ(negative_X.dimensions, 3ul);
-    ASSERT_VECTOR_EQ(negative_X, should_be_negative_X);
+    raytrace::vector N = SQ.normal(C);
+    ASSERT_VECTOR_EQ(negative_X, N);
     {
         raytrace::ray const world_ray{geometry::R3::origin, geometry::R3::basis::X};
         auto inter = SQ.intersect(world_ray).intersect;
@@ -202,7 +183,7 @@ TEST(SquareTest, ScaleRotateTranslate) {
 TEST(SquareTest, Mapping) {
     using namespace raytrace;
     using namespace raytrace::objects;
-    raytrace::objects::square SQ{R3::origin, R3::basis::Z, 10, 10};
+    raytrace::objects::square SQ{20.0_p};
     SQ.set_surface_scale(1.0_p, 1.0_p);
     precision r = 1.0_p;
     {
@@ -231,123 +212,6 @@ TEST(SquareTest, Mapping) {
     }
     {
         raytrace::point const p{0, -r, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{0.0_p, -r};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-}
-
-// Squares use cartesian coordinates for mapping
-TEST(SquareTest, MappingPosX) {
-    using namespace raytrace;
-    using namespace raytrace::objects;
-    raytrace::objects::square SQ{R3::origin, R3::basis::X, 10, 10};
-    SQ.set_surface_scale(1.0_p, 1.0_p);
-    precision r = 1.0_p;
-    {
-        raytrace::point const p{0, 0, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{0.0_p, 0.0_p};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, 0, -r};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{r, 0.0_p};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, r, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{0.0_p, r};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, 0, r};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{-r, 0.0_p};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, -r, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{0.0_p, -r};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-}
-
-// Squares use cartesian coordinates for mapping
-TEST(SquareTest, MappingNegX) {
-    using namespace raytrace;
-    using namespace raytrace::objects;
-    raytrace::objects::square SQ{R3::origin, -R3::basis::X, 10, 10};
-    SQ.set_surface_scale(1.0_p, 1.0_p);
-    precision r = 1.0_p;
-    {
-        raytrace::point const p{0, 0, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{0.0_p, 0.0_p};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, 0, r};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{r, 0.0_p};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, r, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{0.0_p, r};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, 0, -r};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{-r, 0.0_p};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, -r, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{0.0_p, -r};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-}
-
-// Squares use cartesian coordinates for mapping
-TEST(SquareTest, MappingNegY) {
-    using namespace raytrace;
-    using namespace raytrace::objects;
-    raytrace::objects::square SQ{R3::origin, -R3::basis::Y, 10, 10};
-    SQ.set_surface_scale(1.0_p, 1.0_p);
-    precision r = 1.0_p;
-    {
-        raytrace::point const p{0, 0, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{0.0_p, 0.0_p};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{r, 0, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{r, 0.0_p};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, 0, r};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{0.0_p, r};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{-r, 0, 0};
-        image::point const uv = SQ.map(p);
-        image::point const tmp{-r, 0.0_p};
-        EXPECT_POINT_EQ(uv, tmp);
-    }
-    {
-        raytrace::point const p{0, 0, -r};
         image::point const uv = SQ.map(p);
         image::point const tmp{0.0_p, -r};
         EXPECT_POINT_EQ(uv, tmp);

--- a/projects/raytrace/test/gtest_wall.cpp
+++ b/projects/raytrace/test/gtest_wall.cpp
@@ -13,7 +13,7 @@ TEST(WallTest, Type) {
     using namespace raytrace;
     using namespace raytrace::objects;
 
-    raytrace::objects::wall w0{R3::origin, R3::basis::Z, 2.0_p};
+    raytrace::objects::wall w0{2.0_p};
     ASSERT_EQ(w0.get_type(), raytrace::objects::Type::Wall);
 }
 
@@ -21,7 +21,7 @@ TEST(WallTest, Position) {
     using namespace raytrace;
     using namespace raytrace::objects;
     raytrace::point C{7, 7, 7};
-    raytrace::objects::wall w0{C, R3::basis::Z, 2.0_p};
+    raytrace::objects::wall w0{C, R3::identity, 2.0_p};
     ASSERT_POINT_EQ(C, w0.position());
 }
 
@@ -29,7 +29,7 @@ TEST(WallTest, Normals) {
     using namespace raytrace;
     using namespace raytrace::objects;
     raytrace::point C{7, 7, 7};
-    raytrace::objects::wall w0{C, R3::basis::Z, 2.0_p};
+    raytrace::objects::wall w0{C, R3::identity, 2.0_p};
     // shouldn't this return a null in the inside?
     auto should_be_null = w0.normal(C);
     auto should_be_Z = w0.normal(raytrace::point{7, 7, 8});
@@ -39,11 +39,31 @@ TEST(WallTest, Normals) {
     ASSERT_VECTOR_EQ((-R3::basis::Z), should_be_nZ);
 }
 
+TEST(WallTest, NormalsRotated) {
+    using namespace raytrace;
+    using namespace raytrace::objects;
+    raytrace::point C{0, 0, 0};
+    {
+        raytrace::objects::wall w0{C, R3::roll(0.25), 2.0_p};
+        // shouldn't this return a null in the inside?
+        ASSERT_VECTOR_EQ(R3::null, w0.normal(C));
+        ASSERT_VECTOR_EQ((R3::basis::Y), w0.normal(raytrace::point{0, 1, 0}));
+        ASSERT_VECTOR_EQ((-R3::basis::Y), w0.normal(raytrace::point{0, -1, 0}));
+    }
+    {
+        raytrace::objects::wall w0{C, R3::pitch(0.25), 2.0_p};
+        // shouldn't this return a null in the inside?
+        ASSERT_VECTOR_EQ(R3::null, w0.normal(C));
+        ASSERT_VECTOR_EQ(R3::basis::X, w0.normal(raytrace::point{1, 0, 0}));
+        ASSERT_VECTOR_EQ((-R3::basis::X), w0.normal(raytrace::point{-1, 0, 0}));
+    }
+}
+
 TEST(WallTest, InsideOutside) {
     using namespace raytrace;
     using namespace raytrace::objects;
     raytrace::point C{7, 7, 7};
-    raytrace::objects::wall w0{C, R3::basis::Z, 2.0_p};
+    raytrace::objects::wall w0{C, R3::identity, 2.0_p};
     ASSERT_FALSE(w0.is_outside(C));
     ASSERT_TRUE(w0.is_outside(raytrace::point{9, 9, 9}));
     ASSERT_FALSE(w0.is_outside(raytrace::point{7, 7, 8}));
@@ -56,7 +76,7 @@ TEST(WallTest, OnSurface) {
     using namespace raytrace;
     using namespace raytrace::objects;
     raytrace::point C{7, 7, 7};
-    raytrace::objects::wall w0{C, R3::basis::Z, 2.0_p};
+    raytrace::objects::wall w0{C, R3::identity, 2.0_p};
 
     ASSERT_TRUE(w0.is_surface_point(raytrace::point{7, 7, 8}));
     ASSERT_TRUE(w0.is_surface_point(raytrace::point{7, 7, 6}));
@@ -67,9 +87,9 @@ TEST(WallTest, Intersections) {
     using namespace raytrace::objects;
 
     raytrace::point C{0, 0, 0};
-    raytrace::objects::wall w0{C, R3::basis::X, 2.0_p};
+    raytrace::objects::wall w0{C, R3::pitch(0.25), 2.0_p};
 
-    raytrace::ray r0{raytrace::point{2, 1, 1}, -R3::basis::X};
+    raytrace::ray r0{raytrace::point{2, 1, 1}, (-R3::basis::X)};
     raytrace::ray r1{raytrace::point{-2, 1, 1}, R3::basis::X};
     raytrace::ray r2{raytrace::point{2, 1, 1}, R3::basis::Y};
     raytrace::point A{1, 1, 1};
@@ -91,16 +111,24 @@ TEST(WallTest, Rotations) {
     using namespace raytrace;
     using namespace raytrace::objects;
 
-    raytrace::point C{1, 1, 1};
-    raytrace::objects::wall w0{C, R3::basis::X, 2.0_p};
-    w0.rotation(iso::degrees{0.0_p}, iso::degrees{0.0_p}, iso::degrees{180.0_p});
+    raytrace::objects::wall w0{2.0_p};
+    ASSERT_VECTOR_EQ(R3::vector({0, 0, 1}), w0.normal(raytrace::point{0, 0, 1}));
+    ASSERT_VECTOR_EQ(R3::vector({0, 0, -1}), w0.normal(raytrace::point{0, 0, -1}));
+    // it's not cumulative, it's reset to ONLY this
+    w0.rotation(iso::degrees{90.0_p}, iso::degrees{0.0_p}, iso::degrees{0.0_p});
+    ASSERT_VECTOR_EQ(R3::vector({0, 1, 0}), w0.normal(R3::point{0, 1, 0}));
+    ASSERT_VECTOR_EQ(R3::vector({0, -1, 0}), w0.normal(R3::point{0, -1, 0}));
+    // it's not cumulative, it's reset to ONLY this
+    w0.rotation(iso::degrees{0.0_p}, iso::degrees{-90.0_p}, iso::degrees{0.0_p});
+    ASSERT_VECTOR_EQ(R3::vector({1, 0, 0}), w0.normal(R3::point{1, 0, 0}));
+    ASSERT_VECTOR_EQ(R3::vector({-1, 0, 0}), w0.normal(R3::point{-1, 0, 0}));
 }
 
 TEST(WallTest, ColumnMisses) {
     using namespace raytrace;
     using namespace geometry::operators;
-    objects::wall w0{raytrace::point{0, 0, 0}, R3::basis::X, 2.0_p};
-    objects::wall w1{raytrace::point{0, 0, 0}, R3::basis::Y, 2.0_p};
+    objects::wall w0{R3::origin, R3::pitch(0.25), 2.0_p};
+    objects::wall w1{R3::origin, R3::roll(-0.25), 2.0_p};
     objects::overlap column{w0, w1, objects::overlap::type::inclusive};
     {
         raytrace::ray r{raytrace::point{2, 2, 2}, -R3::basis::X};
@@ -127,8 +155,8 @@ TEST(WallTest, ColumnMisses) {
 TEST(WallTest, ColumnHitsDeadCenter) {
     using namespace raytrace;
     using namespace geometry::operators;
-    objects::wall w0{raytrace::point{0, 0, 0}, R3::basis::X, 2.0_p};
-    objects::wall w1{raytrace::point{0, 0, 0}, R3::basis::Y, 2.0_p};
+    objects::wall w0{raytrace::point{0, 0, 0}, R3::pitch(0.25), 2.0_p};
+    objects::wall w1{raytrace::point{0, 0, 0}, R3::roll(-0.25), 2.0_p};
     objects::overlap column{w0, w1, objects::overlap::type::inclusive};
     {
         raytrace::ray r{raytrace::point{2, 0, 0}, (-R3::basis::X)};
@@ -163,8 +191,8 @@ TEST(WallTest, ColumnHitsDeadCenter) {
 TEST(WallTest, ColumnHitsDiagonals) {
     using namespace raytrace;
     using namespace geometry::operators;
-    objects::wall w0{raytrace::point{0, 0, 0}, R3::basis::X, 2.0_p};
-    objects::wall w1{raytrace::point{0, 0, 0}, R3::basis::Y, 2.0_p};
+    objects::wall w0{raytrace::point{0, 0, 0}, R3::pitch(0.25), 2.0_p};
+    objects::wall w1{raytrace::point{0, 0, 0}, R3::roll(-0.25), 2.0_p};
     objects::overlap column{w0, w1, objects::overlap::type::inclusive};
     {
         raytrace::ray r{raytrace::point{2, 2, 2}, raytrace::vector{-1, -1, -1}.normalized()};
@@ -185,9 +213,9 @@ TEST(WallTest, ColumnHitsDiagonals) {
 TEST(WallTest, BoxFromWalls) {
     using namespace raytrace;
     using namespace geometry::operators;
-    objects::wall w0{raytrace::point{0, 0, 0}, R3::basis::X, 2.0_p};
-    objects::wall w1{raytrace::point{0, 0, 0}, R3::basis::Y, 2.0_p};
-    objects::wall w2{raytrace::point{0, 0, 0}, R3::basis::Z, 2.0_p};
+    objects::wall w0{raytrace::point{0, 0, 0}, R3::pitch(0.25), 2.0_p};
+    objects::wall w1{raytrace::point{0, 0, 0}, R3::roll(-0.25), 2.0_p};
+    objects::wall w2{raytrace::point{0, 0, 0}, R3::identity, 2.0_p};
     objects::overlap column{w0, w1, objects::overlap::type::inclusive};
     objects::overlap box{column, w2, objects::overlap::type::inclusive};
     {


### PR DESCRIPTION
Fixes #72

Added rotation in geometry R3 specifically for roll/pitch/yaw and a combined version which replaced object's version.